### PR TITLE
handle multiline input

### DIFF
--- a/lib/logstash/codecs/multiline.rb
+++ b/lib/logstash/codecs/multiline.rb
@@ -151,13 +151,15 @@ class LogStash::Codecs::Multiline < LogStash::Codecs::Base
   def decode(text, &block)
     text = @converter.convert(text)
 
-    match = @grok.match(text)
-    @logger.debug("Multiline", :pattern => @pattern, :text => text,
-                  :match => !match.nil?, :negate => @negate)
+    text.split("\n").each do |line|
+      match = @grok.match(line)
+      @logger.debug("Multiline", :pattern => @pattern, :text => line,
+                    :match => !match.nil?, :negate => @negate)
 
-    # Add negate option
-    match = (match and !@negate) || (!match and @negate)
-    @handler.call(text, match, &block)
+      # Add negate option
+      match = (match and !@negate) || (!match and @negate)
+      @handler.call(line, match, &block)
+    end
   end # def decode
 
   def buffer(text)

--- a/spec/codecs/multiline_spec.rb
+++ b/spec/codecs/multiline_spec.rb
@@ -38,6 +38,20 @@ describe LogStash::Codecs::Multiline do
       insist { events[1]["tags"] }.nil?
     end
 
+    it "should handle new lines in messages" do
+      codec = LogStash::Codecs::Multiline.new("pattern" => '^\s', "what" => "previous")
+      line = "one\ntwo\n  two.2\nthree\n"
+      events = []
+      codec.decode(line) do |event|
+        events << event
+      end
+      codec.flush { |e| events << e }
+      insist { events.size } == 3
+      insist { events[0]["message"] } == "one"
+      insist { events[1]["message"] } == "two\n  two.2"
+      insist { events[2]["message"] } == "three"
+    end
+
     it "should allow grok patterns to be used" do
       codec = LogStash::Codecs::Multiline.new(
         "pattern" => "^%{NUMBER} %{TIME}",


### PR DESCRIPTION
splits incoming messages by new line and processes each sequentially.

Fixes https://github.com/elasticsearch/logstash/issues/1483
