### PR TITLE
Fix an issue when the buffered events make logstash go OOM.

### DIFF
--- a/lib/logstash/codecs/multiline.rb
+++ b/lib/logstash/codecs/multiline.rb
@@ -124,7 +124,7 @@ class LogStash::Codecs::Multiline < LogStash::Codecs::Base
   # if event boundaries are not correctly defined. This settings make sure to flush
   # multiline events after reaching a number of bytes, it is used in combination
   # max_lines.
-  config :max_bytes, :validate => :bytes, :default => "1 MiB"
+  config :max_bytes, :validate => :bytes, :default => "10 MiB"
 
   public
   def register

--- a/lib/logstash/codecs/multiline.rb
+++ b/lib/logstash/codecs/multiline.rb
@@ -188,7 +188,8 @@ class LogStash::Codecs::Multiline < LogStash::Codecs::Base
   def merge_events
     event = LogStash::Event.new(LogStash::Event::TIMESTAMP => @time, "message" => @buffer.join(NL))
     event.tag @multiline_tag if @multiline_tag && @buffer.size > 1
-    event.tag "multiline_over_buffer_limits" if buffer_over_limits?
+    event.tag "multiline_codec_max_bytes_reached" if over_maximun_bytes?
+    event.tag "multiline_codec_max_lines_reached" if over_maximun_lines?
     event
   end
 
@@ -207,8 +208,16 @@ class LogStash::Codecs::Multiline < LogStash::Codecs::Base
     buffer(text)
   end
 
+  def over_maximun_lines?
+    @buffer.size > @max_lines 
+  end
+
+  def over_maximun_bytes?
+    @buffer_bytes >= @max_bytes
+  end
+
   def buffer_over_limits?
-    @buffer.size > @max_lines || @buffer_bytes >= @max_bytes
+    over_maximun_lines? || over_maximun_bytes?
   end
 
   def encode(event)

--- a/lib/logstash/codecs/multiline.rb
+++ b/lib/logstash/codecs/multiline.rb
@@ -116,10 +116,14 @@ class LogStash::Codecs::Multiline < LogStash::Codecs::Base
 
   # The accumulation of events can make logstash exit with an out of memory error
   # if event boundaries are not correctly defined. This settings make sure to flush
-  # multiline events after reaching a number of lines
+  # multiline events after reaching a number of lines, it is used in combination
+  # max_bytes.
   config :max_lines, :validate => :number, :default => 500
 
-  # Maximun size in bytes of the aggregated lines before flushing to queue
+  # The accumulation of events can make logstash exit with an out of memory error
+  # if event boundaries are not correctly defined. This settings make sure to flush
+  # multiline events after reaching a number of bytes, it is used in combination
+  # max_lines.
   config :max_bytes, :validate => :bytes, :default => "1 MiB"
 
   public

--- a/lib/logstash/codecs/multiline.rb
+++ b/lib/logstash/codecs/multiline.rb
@@ -114,10 +114,19 @@ class LogStash::Codecs::Multiline < LogStash::Codecs::Base
   # to events that actually have multiple lines in them.
   config :multiline_tag, :validate => :string, :default => "multiline"
 
+  # The accumulation of events can make logstash exit with an out of memory error
+  # if event boundaries are not correctly defined. This settings make sure to flush
+  # multiline events after reaching a number of lines
+  config :max_lines, :validate => :number, :default => 500
+
+  # Maximun size in bytes of the aggregated lines before flushing to queue
+  config :max_bytes, :validate => :bytes, :default => "1 MiB"
+
   public
   def register
     require "grok-pure" # rubygem 'jls-grok'
     require 'logstash/patterns/core'
+
     # Detect if we are running from a jarfile, pick the right path.
     patterns_path = []
     patterns_path += [LogStash::Patterns::Core.path]
@@ -139,14 +148,14 @@ class LogStash::Codecs::Multiline < LogStash::Codecs::Base
     @grok.compile(@pattern)
     @logger.debug("Registered multiline plugin", :type => @type, :config => @config)
 
-    @buffer = []
+    reset_buffer
+
     @handler = method("do_#{@what}".to_sym)
 
     @converter = LogStash::Util::Charset.new(@charset)
     @converter.logger = @logger
   end # def register
 
-  public
   def decode(text, &block)
     text = @converter.convert(text)
 
@@ -161,31 +170,43 @@ class LogStash::Codecs::Multiline < LogStash::Codecs::Base
 
   def buffer(text)
     @time = LogStash::Timestamp.now if @buffer.empty?
+    @buffer_bytes += text.bytesize
     @buffer << text
   end
 
   def flush(&block)
-    if @buffer.any?
-      event = LogStash::Event.new(LogStash::Event::TIMESTAMP => @time, "message" => @buffer.join(NL))
-      # Tag multiline events
-      event.tag @multiline_tag if @multiline_tag && @buffer.size > 1
-
-      yield event
-      @buffer = []
+    if @buffer.any? 
+      yield merge_events
+      reset_buffer
     end
+  end
+
+  def merge_events
+    event = LogStash::Event.new(LogStash::Event::TIMESTAMP => @time, "message" => @buffer.join(NL))
+    event.tag @multiline_tag if @multiline_tag && @buffer.size > 1
+    event.tag "multiline_over_buffer_limits" if buffer_over_limits?
+    event
+  end
+
+  def reset_buffer
+    @buffer = []
+    @buffer_bytes = 0
   end
 
   def do_next(text, matched, &block)
     buffer(text)
-    flush(&block) if !matched
+    flush(&block) if !matched || buffer_over_limits?
   end
 
   def do_previous(text, matched, &block)
-    flush(&block) if !matched
+    flush(&block) if !matched || buffer_over_limits?
     buffer(text)
   end
 
-  public
+  def buffer_over_limits?
+    @buffer.size > @max_lines || @buffer_bytes >= @max_bytes
+  end
+
   def encode(event)
     # Nothing to do.
     @on_event.call(event, event)

--- a/spec/codecs/multiline_spec.rb
+++ b/spec/codecs/multiline_spec.rb
@@ -164,7 +164,8 @@ describe LogStash::Codecs::Multiline do
     let(:events) { decode_events }
     let(:unmerged_events_count) { events.collect { |event| event["message"].split(LogStash::Codecs::Multiline::NL).size }.inject(&:+) }
 
-    context "break on maximum_lines" do let(:max_lines) { rand(10..100) }
+    context "break on maximum_lines" do
+      let(:max_lines) { rand(10..100) }
       let(:options) {
         {
           "pattern" => "^-",

--- a/spec/codecs/multiline_spec.rb
+++ b/spec/codecs/multiline_spec.rb
@@ -162,9 +162,9 @@ describe LogStash::Codecs::Multiline do
     let(:random_number_of_events) { rand(300..1000) }
     let(:sample_event) { "- Sample event" }
     let(:events) { decode_events }
+    let(:unmerged_events_count) { events.collect { |event| event["message"].split(LogStash::Codecs::Multiline::NL).size }.inject(&:+) }
 
     context "break on maximum_lines" do let(:max_lines) { rand(10..100) }
-      let(:expected_events) {  (1.0 * random_number_of_events / max_lines).ceil }
       let(:options) {
         {
           "pattern" => "^-",
@@ -175,11 +175,11 @@ describe LogStash::Codecs::Multiline do
       }
 
       it "flushes on a maximum lines" do
-        expect(events.size).to eq(expected_events)
+        expect(unmerged_events_count).to eq(random_number_of_events)
       end
 
       it "tags the event" do
-        expect(events.first["tags"]).to include("multiline_over_buffer_limits")
+        expect(events.first["tags"]).to include("multiline_codec_max_lines_reached")
       end
     end
 
@@ -195,13 +195,11 @@ describe LogStash::Codecs::Multiline do
       }
 
       it "flushes on a maximum bytes size" do
-        unmerged_events = events.collect { |event| event["message"].split(LogStash::Codecs::Multiline::NL).size }.inject(&:+)
-        expect(unmerged_events).to eq(random_number_of_events)
+        expect(unmerged_events_count).to eq(random_number_of_events)
       end
 
       it "tags the event" do
-        events = decode_events
-        expect(events.first["tags"]).to include("multiline_over_buffer_limits")
+        expect(events.first["tags"]).to include("multiline_codec_max_bytes_reached")
       end
     end
   end

--- a/spec/supports/helpers.rb
+++ b/spec/supports/helpers.rb
@@ -1,0 +1,14 @@
+require "lib/logstash/codecs/multiline"
+
+def decode_events
+  multiline =  LogStash::Codecs::Multiline.new(options)
+
+  events = []
+  random_number_of_events.times do |n|
+    multiline.decode(sample_event) { |event| events << event }
+  end
+
+  # Grab the in-memory-event
+  multiline.flush { |event| events << event }
+  events
+end


### PR DESCRIPTION
Fix an issue when the buffered events is never send to pipeline and just keep growing and make logstash go OOM. I have added a `max_lines` options to force a flush to queue after a
maximum buffered events is saved in the buffer, default is set to 100 lines.

Fixes: https://github.com/logstash-plugins/logstash-codec-multiline/issues/4, https://github.com/elastic/logstash/issues/2984, https://github.com/elastic/logstash/issues/2015
