### PR TITLE
Fix/relative path

### DIFF
--- a/logstash-codec-multiline.gemspec
+++ b/logstash-codec-multiline.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-multiline'
-  s.version         = '0.1.7'
+  s.version         = '0.1.8'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The multiline codec will collapse multiline messages and merge them into a single event."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/supports/helpers.rb
+++ b/spec/supports/helpers.rb
@@ -1,5 +1,3 @@
-require "lib/logstash/codecs/multiline"
-
 def decode_events
   multiline =  LogStash::Codecs::Multiline.new(options)
 


### PR DESCRIPTION
unnecessary require in the `support/helpers` causing the test to fail when running the full integration test suite.
