### PR TITLE
Prepare for Auto-flush, introduce listeners to carry state with callback API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.5
+ - Add auto_flush config option, with no default. If not set, no auto_flush is done.
+ - Add evict method to identity_map_codec that allows for an input, when done with an identity, to auto_flush and remove the identity from the map.
+
 ## 2.0.4
  - Add constructional method to allow an eviction specific block to be set.
 

--- a/lib/logstash/codecs/auto_flush.rb
+++ b/lib/logstash/codecs/auto_flush.rb
@@ -1,0 +1,66 @@
+# encoding: utf-8
+require "concurrent"
+
+module LogStash module Codecs class AutoFlush
+  def initialize(mc, interval)
+    @mc, @interval = mc, interval
+    @stopped = Concurrent::AtomicBoolean.new # false by default
+  end
+
+  def start
+    # can't start if pipeline is stopping
+    return self if stopped?
+    if pending?
+      @task.reset
+    elsif finished?
+      @task = Concurrent::ScheduledTask.execute(@interval) do
+        @mc.auto_flush()
+      end
+    # else the task is executing
+    end
+    self
+  end
+
+  def finished?
+    return true if @task.nil?
+    @task.fulfilled?
+  end
+
+  def pending?
+    @task && @task.pending?
+  end
+
+  def stopped?
+    @stopped.value
+  end
+
+  def stop
+    @stopped.make_true
+    @task.cancel if pending?
+  end
+end
+
+class AutoFlushUnset
+  def initialize(mc, interval)
+  end
+
+  def pending?
+    false
+  end
+
+  def stopped?
+    true
+  end
+
+  def start
+    self
+  end
+
+  def finished?
+    true
+  end
+
+  def stop
+    self
+  end
+end end end

--- a/logstash-codec-multiline.gemspec
+++ b/logstash-codec-multiline.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-multiline'
-  s.version         = '2.0.4'
+  s.version         = '2.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The multiline codec will collapse multiline messages and merge them into a single event."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/codecs/auto_flush_spec.rb
+++ b/spec/codecs/auto_flush_spec.rb
@@ -1,0 +1,118 @@
+# encoding: utf-8
+require "logstash/codecs/auto_flush"
+require "logstash/codecs/multiline"
+require_relative "../supports/helpers.rb"
+
+describe "AutoFlush and AutoFlushUnset" do
+  let(:flushable)  { AutoFlushTracer.new }
+  let(:flush_wait) { 0.1 }
+
+  describe LogStash::Codecs::AutoFlush do
+    subject { described_class.new(flushable, flush_wait) }
+
+    context "when initialized" do
+      it "#pending? is false" do
+        expect(subject.pending?).to be_falsy
+      end
+
+      it "#stopped? is false" do
+        expect(subject.stopped?).to be_falsy
+      end
+
+      it "#finished? is true" do
+        expect(subject.finished?).to be_truthy
+      end
+    end
+
+    context "when started" do
+      let(:flush_wait) { 20 }
+
+      before { subject.start }
+      after  { subject.stop }
+
+      it "#pending? is true" do
+        expect(subject.pending?).to be_truthy
+      end
+
+      it "#stopped? is false" do
+        expect(subject.stopped?).to be_falsy
+      end
+
+      it "#finished? is false" do
+        expect(subject.finished?).to be_falsy
+      end
+    end
+
+    context "when finished" do
+      before do
+        subject.start
+        sleep flush_wait + 0.1
+      end
+
+      after  { subject.stop }
+
+      it "calls auto_flush on flushable" do
+        expect(flushable.trace_for(:auto_flush)).to be_truthy
+      end
+
+      it "#pending? is false" do
+        expect(subject.pending?).to be_falsy
+      end
+
+      it "#stopped? is false" do
+        expect(subject.stopped?).to be_falsy
+      end
+
+      it "#finished? is true" do
+        expect(subject.finished?).to be_truthy
+      end
+    end
+
+    context "when stopped" do
+      before do
+        subject.start
+        subject.stop
+      end
+
+      it "does not call auto_flush on flushable" do
+        expect(flushable.trace_for(:auto_flush)).to be_falsy
+      end
+
+      it "#pending? is false" do
+        expect(subject.pending?).to be_falsy
+      end
+
+      it "#stopped? is true" do
+        expect(subject.stopped?).to be_truthy
+      end
+
+      it "#finished? is false" do
+        expect(subject.finished?).to be_falsy
+      end
+    end
+  end
+
+  describe LogStash::Codecs::AutoFlushUnset do
+    subject { described_class.new(flushable, 2) }
+
+    it "#pending? is false" do
+      expect(subject.pending?).to be_falsy
+    end
+
+    it "#stopped? is true" do
+      expect(subject.stopped?).to be_truthy
+    end
+
+    it "#finished? is true" do
+      expect(subject.finished?).to be_truthy
+    end
+
+    it "#start returns self" do
+      expect(subject.start).to eq(subject)
+    end
+
+    it "#stop returns self" do
+      expect(subject.start).to eq(subject)
+    end
+  end
+end

--- a/spec/supports/helpers.rb
+++ b/spec/supports/helpers.rb
@@ -1,3 +1,5 @@
+
+
 def decode_events
   multiline =  LogStash::Codecs::Multiline.new(options)
 
@@ -9,4 +11,113 @@ def decode_events
   # Grab the in-memory-event
   multiline.flush { |event| events << event }
   events
+end
+
+class LineListener
+  attr_reader :data, :path, :queue, :codec
+  # use attr_reader to define noop methods of Listener API
+  attr_reader :deleted, :created, :error, :eof #, :line
+
+  def initialize(queue, codec, path = '')
+    # store state from upstream
+    @queue = queue
+    @codec = codec
+    @path = path
+  end
+
+  # receives a line from some upstream source
+  # and sends it downstream
+  def accept(data)
+    @codec.accept dup_adding_state(data)
+  end
+
+  def process_event(event)
+    event["path"] = path
+    @queue << event
+  end
+
+  def add_state(data)
+    @data = data
+    self
+  end
+
+  private
+
+  # dup and add state for downstream
+  def dup_adding_state(line)
+    self.class.new(queue, codec, path).add_state(line)
+  end
+end
+
+class LineErrorListener < LineListener
+  def process_event(event)
+    raise StandardError.new("OMG, Daleks!")
+  end
+end
+
+class MultilineRspec < LogStash::Codecs::Multiline
+  def internal_buffer
+    @buffer
+  end
+  def buffer_size
+    @buffer.size
+  end
+end
+
+class TracerBase
+  def initialize() @tracer = []; end
+
+  def trace_for(symbol)
+    params = @tracer.assoc(symbol)
+    params.nil? ? false : params.last
+  end
+
+  def clear()
+    @tracer.clear()
+  end
+end
+
+class MultilineLogTracer < TracerBase
+  def warn(*args) @tracer.push [:warn, args]; end
+  def error(*args) @tracer.push [:error, args]; end
+  def debug(*args) @tracer.push [:debug, args]; end
+  def info(*args) @tracer.push [:info, args]; end
+
+  def info?() true; end
+  def debug?() true; end
+  def warn?() true; end
+  def error?() true; end
+end
+
+class AutoFlushTracer < TracerBase
+  def auto_flush() @tracer.push [:auto_flush, true]; end
+end
+
+class IdentityMapCodecTracer < TracerBase
+  def clone() self.class.new; end
+  def decode(data) @tracer.push [:decode, data]; end
+  def encode(event) @tracer.push [:encode, event]; end
+  def flush(&block) @tracer.push [:flush, block.call]; end
+  def close() @tracer.push [:close, true]; end
+  def logger() @logger ||= MultilineLogTracer.new; end
+end
+
+RSpec::Matchers.define(:have_an_empty_buffer) do
+  match do |actual|
+    actual.buffer_size.zero?
+  end
+
+  failure_message do
+    "Expecting #{actual.buffer_size} to be 0"
+  end
+end
+
+RSpec::Matchers.define(:match_path_and_line) do |path, line|
+  match do |actual|
+    actual["path"] == path && actual["message"] == line.join($/)
+  end
+
+  failure_message do
+    "Expecting #{actual['path']} to equal `#{path}` and #{actual["message"]} to equal #{line.join($/)}"
+  end
 end


### PR DESCRIPTION
NOTES TO REVIEWERS:
- Both the IdentityMapCodec and the Multiline have been changed.
- Both are backward compatible and retain the block based API.
- New `accept` method that takes a listener as an argument.
- For these two classes, Listeners must implement `accept()` and `process_event(event)`.
- Listeners usually hold long term upstream state (context) and transient data for downstream to process.
- The listener based tests are a WIP and will be tidied up.
- A lot more comments need to be added.
- Some classes will need to be in their own files but are included for readability.
- These changes are a prelude to a better component based dataflow channel in each input.
- Auto-flush is implemented.
