### PR TITLE
Allow disabling splitting original message to lines

### DIFF
--- a/lib/logstash/codecs/multiline.rb
+++ b/lib/logstash/codecs/multiline.rb
@@ -132,6 +132,9 @@ module LogStash module Codecs class Multiline < LogStash::Codecs::Base
   # auto_flush_interval. No default.  If unset, no auto_flush. Units: seconds
   config :auto_flush_interval, :validate => :number
 
+  # Whether to split original message to lines.
+  config :split_original, :validate => :boolean, :default => true
+
   public
 
   def register
@@ -188,7 +191,9 @@ module LogStash module Codecs class Multiline < LogStash::Codecs::Base
 
   def decode(text, &block)
     text = @converter.convert(text)
-    text.split("\n").each do |line|
+
+    lines = @split_original ? text.split("\n") : [text]
+    lines.each do |line|
       match = @grok.match(line)
       @logger.debug("Multiline", :pattern => @pattern, :text => line,
                     :match => !match.nil?, :negate => @negate)
@@ -263,7 +268,7 @@ module LogStash module Codecs class Multiline < LogStash::Codecs::Base
   end
 
   def over_maximum_lines?
-    @buffer.size > @max_lines
+    @buffer.size >= @max_lines
   end
 
   def over_maximum_bytes?


### PR DESCRIPTION
Sometimes it's necessary to join multiple messages from the input, without splitting the original message by new lines (example: joining es bulk api input messages)
