### PR TITLE
[WIP] proper delimiter support for line based input

### DIFF
--- a/lib/logstash/codecs/multiline.rb
+++ b/lib/logstash/codecs/multiline.rb
@@ -115,6 +115,9 @@ module LogStash module Codecs class Multiline < LogStash::Codecs::Base
   # This only affects "plain" format logs since JSON is `UTF-8` already.
   config :charset, :validate => ::Encoding.name_list, :default => "UTF-8"
 
+  # Change the delimiter that separates lines
+  config :delimiter, :validate => :string, :default => "\n"
+
   # Tag multiline events with a given tag. This tag will only be added
   # to events that actually have multiple lines in them.
   config :multiline_tag, :validate => :string, :default => "multiline"
@@ -137,6 +140,7 @@ module LogStash module Codecs class Multiline < LogStash::Codecs::Base
   config :auto_flush_interval, :validate => :number
 
   def register
+    @tokenizer = FileWatch::BufferedTokenizer.new(@delimiter)
     @grok = Grok.new
     @patterns_dir = [LogStash::Patterns::Core.path] + @patterns_dir
     @patterns_dir.each do |path|
@@ -159,21 +163,28 @@ module LogStash module Codecs class Multiline < LogStash::Codecs::Base
 
     @converter = LogStash::Util::Charset.new(@charset)
     @converter.logger = @logger
+
+    # TODO: (colin) I don't really understand this @last_seen_listener poutine. I needed to create
+    # this lamda to DRY across the close & auto_flush methods to pass the closure to the new
+    # @tokenizer which I figured needs to be flushed upon close. there does not seem to be
+    # explicit tests for this closing logic.
+    # what is not clear here is the initialization of @last_seen_listener which gets initialized
+    # in the accept method but the close method systematically call auto_flush which assumes the
+    # existence of @last_seen_listener. this whole logic is confusing and should be either made
+    # more explicit and self documenting OR documentation should be prodided.
+    @auto_flush_block = lambda do |event|
+      @last_seen_listener.process_event(event)
+    end
+
     if @auto_flush_interval
       # will start on first decode
       @auto_flush_runner = AutoFlush.new(self, @auto_flush_interval)
     end
   end
 
-  def decode(text, &block)
-    text = @converter.convert(text)
-    text.split("\n").each do |line|
-      match = @grok.match(line)
-      @logger.debug("Multiline", :pattern => @pattern, :text => line, :match => !match.nil?, :negate => @negate)
-
-      # Add negate option
-      match = (match and !@negate) || (!match and @negate)
-      @handler.call(line, match, &block)
+  def decode(data, &block)
+    @tokenizer.extract(data.force_encoding("ASCII-8BIT")).each do |line|
+      match_line(@converter.convert(line), &block)
     end
   end
 
@@ -182,31 +193,35 @@ module LogStash module Codecs class Multiline < LogStash::Codecs::Base
     @on_event.call(event, event)
   end
 
+  # this is the termination or final flush API
+  #
+  # @param block [Proc] the closure that will be called for all events that need to be flushed.
   def flush(&block)
-    if block_given? && @buffer.any?
-      no_error = true
-      events = merge_events
-      begin
-        yield events
-      rescue ::Exception => e
-        # need to rescue everything
-        # likliest cause: backpressure or timeout by exception
-        # can't really do anything but leave the data in the buffer for next time if there is one
-        @logger.error("Multiline: flush downstream error", :exception => e)
-        no_error = false
-      end
-      reset_buffer if no_error
-    end
+    remainder = @tokenizer.flush
+    match_line(@converter.convert(remainder), &block) unless remainder.empty?
+    flush_buffered_events(&block)
   end
 
+  # TODO: (colin) I believe there is a problem here in calling auto_flush. auto_flush depends on
+  # @auto_flush_block which references @last_seen_listener which is only initialized in the context of
+  # IdentityMapCodec which in turn I believe cannot by assumed. the multiline codec could run without
+  # IdentityMapCodec.
   def close
     if auto_flush_runner.pending?
       #will cancel task if necessary
       auto_flush_runner.stop
     end
+
+    remainder = @tokenizer.flush
+    match_line(@converter.convert(remainder), &@auto_flush_block) unless remainder.empty?
+
     auto_flush
   end
 
+  # TODO: (colin) what is the pupose of this accept method? AFAICT it is only used if this codec is used
+  # within the IdentityMapCodec. it is not clear when & in which context this method is used.
+  # I believe the codec should still be able to live outside the context of an IdentityMapCodec but there
+  # are usage of ivars like @last_seen_listener only inititalized int the context of IdentityMapCodec.
   def accept(listener)
     # memoize references to listener that holds upstream state
     @previous_listener = @last_seen_listener || listener
@@ -216,9 +231,9 @@ module LogStash module Codecs class Multiline < LogStash::Codecs::Base
     end
   end
 
-  def buffer(text)
-    @buffer_bytes += text.bytesize
-    @buffer.push(text)
+  def buffer(line)
+    @buffer_bytes += line.bytesize
+    @buffer.push(line)
   end
 
   def reset_buffer
@@ -226,10 +241,11 @@ module LogStash module Codecs class Multiline < LogStash::Codecs::Base
     @buffer_bytes = 0
   end
 
+  # TODO: (colin) this method is not clearly documented as being required by the AutoFlush class & tasks.
+  # I belive there is a problem here with the usage of @auto_flush_block which assumes to be in the
+  # context of an IdentityMapCodec but the multiline codec could run without IdentityMapCodec
   def auto_flush
-    flush do |event|
-      @last_seen_listener.process_event(event)
-    end
+    flush_buffered_events(&@auto_flush_block)
   end
 
   # TODO: (colin) auto_flush_active? doesn't seem to be used anywhere. any reason to keep this api?
@@ -237,7 +253,41 @@ module LogStash module Codecs class Multiline < LogStash::Codecs::Base
     !@auto_flush_interval.nil?
   end
 
-  private
+  # private
+
+  # merge all currently bufferred events and call the passed block for the resulting merged event
+  #
+  # @param block [Proc] the closure that will be called for the resulting merged event
+  def flush_buffered_events(&block)
+    if block_given? && @buffer.any?
+      no_error = true
+      event = merge_events
+      begin
+        yield event
+      rescue ::Exception => e
+        # need to rescue everything
+        # likliest cause: backpressure or timeout by exception
+        # can't really do anything but leave the data in the buffer for next time if there is one
+        @logger.error("Multiline: buffered events flush downstream error", :exception => e)
+        no_error = false
+      end
+      reset_buffer if no_error
+    end
+  end
+
+  # evalutate if a given line matches the configured pattern and call the appropriate do_next or do_previous
+  # handler given the match state.
+  #
+  # @param line [String] the string to match against the pattern
+  # @param block [Proc] the closure that will be called for each event that might result after processing this line
+  def match_line(line, &block)
+    match = @grok.match(line)
+    @logger.debug? && @logger.debug("Multiline", :pattern => @pattern, :line => line, :match => !match.nil?, :negate => @negate)
+
+    # Add negate option
+    match = (match and !@negate) || (!match and @negate)
+    @handler.call(line, match, &block)
+  end
 
   def merge_events
     event = LogStash::Event.new(LogStash::Event::TIMESTAMP => @time, "message" => @buffer.join(NL))
@@ -255,16 +305,16 @@ module LogStash module Codecs class Multiline < LogStash::Codecs::Base
     doing_previous? ? @previous_listener : @last_seen_listener
   end
 
-  def do_next(text, matched, &block)
-    buffer(text)
+  def do_next(line, matched, &block)
+    buffer(line)
     auto_flush_runner.start
-    flush(&block) if !matched || buffer_over_limits?
+    flush_buffered_events(&block) if !matched || buffer_over_limits?
   end
 
-  def do_previous(text, matched, &block)
-    flush(&block) if !matched || buffer_over_limits?
+  def do_previous(line, matched, &block)
+    flush_buffered_events(&block) if !matched || buffer_over_limits?
     auto_flush_runner.start
-    buffer(text)
+    buffer(line)
   end
 
   def over_maximum_lines?

--- a/lib/logstash/codecs/multiline.rb
+++ b/lib/logstash/codecs/multiline.rb
@@ -118,6 +118,10 @@ module LogStash module Codecs class Multiline < LogStash::Codecs::Base
   # Change the delimiter that separates lines
   config :delimiter, :validate => :string, :default => "\n"
 
+  # Assume data received from input plugin as line based. For some input plugins
+  # like stdin or tcp/udp data is not line based and this option should be set to false.
+  config :line_based_input, :validate => :boolean, :default  => true
+
   # Tag multiline events with a given tag. This tag will only be added
   # to events that actually have multiple lines in them.
   config :multiline_tag, :validate => :string, :default => "multiline"
@@ -183,6 +187,8 @@ module LogStash module Codecs class Multiline < LogStash::Codecs::Base
   end
 
   def decode(data, &block)
+    data = data + @delimiter if @line_based_input
+
     @tokenizer.extract(data.force_encoding("ASCII-8BIT")).each do |line|
       match_line(@converter.convert(line), &block)
     end


### PR DESCRIPTION
- introduction of the `BufferedTokenizer` to correctly parse delimited input across read blocks. the previous implementation first assumed hardcoded `\n` delimiter and also assumed that the delimiter was always part of the same input block which is obviously not true for streaming data (stdin, tcp, etc) which is read by fixed sized chunks and passed to the codec in which case **lines split across blocks were not correctly processed**.
- **this PR is flagged as a WIP** because I have inlined many `TODO:`s that need to be clarified with the help of @guyboertje who introduced the latest changes related to identity map and auto flushing. In particular I think the implementation assumes it will run under an identity map codec which I do not believe is true, for example if used with the stdin input.
- the pre-PR implementation assumed the implicit line termination of the passed data to the `decode` method. Obviously this is wrong, and cannot work with the `BufferedTokenizer`. All specs needed to be adjusted to add a line terminator the the passed lines. 
