### PR TITLE
remove obsolete seting `type` from example

### DIFF
--- a/lib/logstash/codecs/multiline.rb
+++ b/lib/logstash/codecs/multiline.rb
@@ -68,7 +68,6 @@ require "logstash/codecs/auto_flush"
 # [source,ruby]
 #     filter {
 #       multiline {
-#         type => "somefiletype"
 #         pattern => "\\$"
 #         what => "next"
 #       }


### PR DESCRIPTION
The example raises this error when I use it with logstash 2.3.1: 

> The setting `type` in plugin `multiline` is obsolete and is no longer available. You can achieve this same behavior with the new conditionals, like: `if [type] == \"sometype\" { multiline { ... } }`. If you have any questions about this, you are invited to visit https://discuss.elastic.co/c/logstash and ask.
