### PR TITLE
Update documentation to include time unit

### DIFF
--- a/lib/logstash/codecs/multiline.rb
+++ b/lib/logstash/codecs/multiline.rb
@@ -128,8 +128,8 @@ module LogStash module Codecs class Multiline < LogStash::Codecs::Base
   config :max_bytes, :validate => :bytes, :default => "10 MiB"
 
   # The accumulation of multiple lines will be converted to an event when either a
-  # matching new line is seen or there has been no new data appended for this time
-  # auto_flush_interval. No default.  If unset, no auto_flush. Units: seconds
+  # matching new line is seen or there has been no new data appended for this many
+  # seconds. No default.  If unset, no auto_flush. Units: seconds
   config :auto_flush_interval, :validate => :number
 
   public


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

The time unit is not shown on the documentation page (https://www.elastic.co/guide/en/logstash/current/plugins-codecs-multiline.html#plugins-codecs-multiline-auto_flush_interval).

With this change, it is visible.