### PR TITLE
Add sequencer feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.3
+  - Add event sequencer functionality
+
 ## 3.0.2
   - Fix log levels
 


### PR DESCRIPTION
Hi,

I ran into the same issue as mentioned in https://logstash.jira.com/browse/LOGSTASH-192 where my applications logged so many events on the exact same timestamp and then when using Kibana to view those logs, the order is completely lost.

I initially wrote a filter plugin, but since I'm using multiple pipeline workers for Logstash, I cannot guarantee the order when it gets to the filter stage, which is why I ended up modifying the multiline codec plugin which I'm already using to parse Java log files (with stack traces) written to syslog.

The changes included in this pull request are working for my use case, where I'm using the mutliline codec for a `file` input plugin.

I'm not all that familiar with Ruby or the Logstash plugins, so I'm not sure if there was another way that I can add event sequencing when using the `file` input plugin and the `multiline` codec plugin when making use of multiple pipeline workers for Logstash.

Now that I have this, I'm just waiting on Kibana to be able to sort on 2 columns simultaneously (`@timestamp` and this sequence field)

Any kind of feedback on this feature would be much appreciated!

Kind regards,
Chris