### PR TITLE
Warn users not to use multicodec with inputs that support multiple hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.3
+  - Docs: Add note indicating that the multiline codec should not be used with input plugins that support multiple hosts
+
 ## 3.0.2
   - Fix log levels
 

--- a/lib/logstash/codecs/multiline.rb
+++ b/lib/logstash/codecs/multiline.rb
@@ -7,6 +7,12 @@ require "logstash/codecs/auto_flush"
 # The multiline codec will collapse multiline messages and merge them into a
 # single event.
 #
+# IMPORTANT: If you are using a Logstash input plugin that supports multiple
+# hosts, such as the <<plugins-inputs-beats>> input plugin, you should not use
+# the multiline codec to handle multiline events. Doing so may result in the
+# mixing of streams and corrupted event data. In this situation, you need to
+# handle multiline events before sending the event data to Logstash. 
+#
 # The original goal of this codec was to allow joining of multiline messages
 # from files into a single event. For example, joining Java exception and
 # stacktrace messages into a single event.

--- a/logstash-codec-multiline.gemspec
+++ b/logstash-codec-multiline.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-multiline'
-  s.version         = '3.0.3'
+  s.version         = '3.0.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The multiline codec will collapse multiline messages and merge them into a single event."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Another PR related to https://github.com/logstash-plugins/logstash-input-beats/issues/199

@ppf2 @acchen97  I think we should also mention this in the doc for the multiline codec. 
