### PR TITLE
Make sure the devutils helper are loaded

### DIFF
--- a/spec/codecs/auto_flush_spec.rb
+++ b/spec/codecs/auto_flush_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require "logstash/devutils/rspec/spec_helper"
 require "logstash/codecs/auto_flush"
 require "logstash/codecs/multiline"
 require_relative "../supports/helpers.rb"

--- a/spec/codecs/multiline_spec.rb
+++ b/spec/codecs/multiline_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require "logstash/devutils/rspec/spec_helper"
 require "logstash/codecs/multiline"
 require "logstash/event"
 require "insist"


### PR DESCRIPTION
Make sure the devutils helper are loaded before any test to make sure
the log4j logger is correctly setup

Fixes: #53
