### PR TITLE
Fix debug output for grok match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.6
+  - Fix debug output for grok match
+
 ## 3.0.3
   - Docs: Add note indicating that the multiline codec should not be used with input plugins that support multiple hosts
 

--- a/lib/logstash/codecs/multiline.rb
+++ b/lib/logstash/codecs/multiline.rb
@@ -198,7 +198,7 @@ module LogStash module Codecs class Multiline < LogStash::Codecs::Base
     text.split("\n").each do |line|
       match = @grok.match(line)
       @logger.debug("Multiline", :pattern => @pattern, :text => line,
-                    :match => !match.nil?, :negate => @negate)
+                    :match => (match != false), :negate => @negate)
 
       # Add negate option
       match = (match and !@negate) || (!match and @negate)

--- a/logstash-codec-multiline.gemspec
+++ b/logstash-codec-multiline.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-multiline'
-  s.version         = '3.0.5'
+  s.version         = '3.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The multiline codec will collapse multiline messages and merge them into a single event."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
`@grok.match` returns `false` if no match was found, and a `Grok::Match` object otherwise (https://github.com/jordansissel/ruby-grok/blob/master/lib/grok.rb).

Checking the return value with `!match.nil?` is incorrect, as `!false.nil?` is `true` - so the debug output here will always be `true` regardless of whether the grok pattern matched or not.

This fixes it.