### PR TITLE
 #58 make clone method safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.9
+  - Fixed concurrency issue causing random failures when multiline codec was used together with a multi-threaded input plugin
+
 ## 3.0.8
   - Update gemspec summary
 

--- a/lib/logstash/codecs/multiline.rb
+++ b/lib/logstash/codecs/multiline.rb
@@ -297,4 +297,9 @@ module LogStash module Codecs class Multiline < LogStash::Codecs::Base
   def auto_flush_runner
     @auto_flush_runner || AutoFlushUnset.new(nil, nil)
   end
+
+  def initialize_copy(source)
+    super
+    register
+  end
 end end end # class LogStash::Codecs::Multiline

--- a/logstash-codec-multiline.gemspec
+++ b/logstash-codec-multiline.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-multiline'
-  s.version         = '3.0.8'
+  s.version         = '3.0.9'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Merges multiline messages into a single event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixes #58 

The problem was that our `clone` method wasn't safe (not the flush as I initially thought). This lead to the `@buffer` array being shared across instances in some situations when using `.cloned` instances of the code in multi-threaded inputs like the udp input.
=> fixed by making `.clone` set up a clean buffer via `register` fixes this (as well as ensures that we set up the codec's mutable state cleanly for the clones in general)
  