### PR TITLE
Fix no method 'map_cleanup' for nil class error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.10
+  - Fixed [multiline codec - #32](https://github.com/logstash-plugins/logstash-codec-multiline/issues/32) `no method map_cleanup for nil class` error when shutting down.
+
 ## 3.0.9
   - Fixed concurrency issue causing random failures when multiline codec was used together with a multi-threaded input plugin
 

--- a/lib/logstash/codecs/identity_map_codec.rb
+++ b/lib/logstash/codecs/identity_map_codec.rb
@@ -52,6 +52,7 @@ module LogStash module Codecs class IdentityMapCodec
         while running? do
           sleep @interval
           break if !running?
+          break if @listener.nil?
           @listener.send(@method_symbol)
         end
       end
@@ -59,7 +60,7 @@ module LogStash module Codecs class IdentityMapCodec
     end
 
     def running?
-      @running.value
+      @running.true?
     end
 
     def stop

--- a/logstash-codec-multiline.gemspec
+++ b/logstash-codec-multiline.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-multiline'
-  s.version         = '3.0.9'
+  s.version         = '3.0.10'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Merges multiline messages into a single event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Difficult to verify as fixed, community made a similar fix successfully.

Some tests in the file input can fail with this error but its not material.