### PR TITLE
Fix: avoid long thread sleeps on codec close

### DIFF
--- a/lib/logstash/codecs/identity_map_codec.rb
+++ b/lib/logstash/codecs/identity_map_codec.rb
@@ -54,7 +54,7 @@ module LogStash module Codecs class IdentityMapCodec
           thread.name = @method_symbol.to_s if thread.respond_to?(:name)
         end
         while running? do
-          sleep @interval # second thread still sleep (park-ed here)
+          sleep @interval
           break if !running?
           break if (listener = @listener).nil?
           listener.send(@method_symbol)

--- a/lib/logstash/codecs/identity_map_codec.rb
+++ b/lib/logstash/codecs/identity_map_codec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 require "logstash/namespace"
-require "thread_safe"
-require "concurrent"
+require "concurrent/atomic/atomic_boolean"
+require "concurrent/map"
 
 # This class is a Codec duck type
 # Using Composition, it maps from a stream identity to
@@ -109,7 +109,7 @@ module LogStash module Codecs class IdentityMapCodec
   def initialize(codec)
     @base_codec = codec
     @base_codecs = [codec]
-    @identity_map = ThreadSafe::Hash.new &method(:codec_builder)
+    @identity_map = Concurrent::Hash.new &method(:codec_builder)
     @max_identities = MAX_IDENTITIES
     @evict_timeout = EVICT_TIMEOUT
     cleaner_interval(CLEANER_INTERVAL)

--- a/lib/logstash/codecs/identity_map_codec.rb
+++ b/lib/logstash/codecs/identity_map_codec.rb
@@ -49,10 +49,9 @@ module LogStash module Codecs class IdentityMapCodec
       return self if running?
       @running.make_true
       @thread = Thread.start do
-        Thread.current.tap do |thread|
-          # to be able to distinguish cleaner from auto_flusher in thread dumps
-          thread.name = @method_symbol.to_s if thread.respond_to?(:name)
-        end
+        class_name = @listener.class.name.split('::').last # IdentityMapCodec
+        LogStash::Util.set_thread_name("#{class_name}##{@method_symbol}")
+
         while running? do
           sleep @interval
           break if !running?

--- a/logstash-codec-multiline.gemspec
+++ b/logstash-codec-multiline.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'logstash-patterns-core'
   s.add_runtime_dependency 'jls-grok', '~> 0.11.1'
+  s.add_runtime_dependency 'concurrent-ruby'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'insist'


### PR DESCRIPTION
The PR fixes a stalled shutdown process due `codec.close`, details from https://github.com/logstash-plugins/logstash-input-file/issues/298:
> In rare cases (multiple file inputs helps reproduce the issue) as the plugin attempts to stop it's identity codec, it ends up waking up the cleaner thread but the thread gets right back to (a [5 minute](https://github.com/logstash-plugins/logstash-codec-multiline/blob/v3.0.10/lib/logstash/codecs/identity_map_codec.rb#L104)) sleep (when the [`cleaner.stop`](https://github.com/logstash-plugins/logstash-codec-multiline/blob/v3.0.10/lib/logstash/codecs/identity_map_codec.rb#L70) -> [`wakeup`](https://github.com/logstash-plugins/logstash-codec-multiline/blob/v3.0.10/lib/logstash/codecs/identity_map_codec.rb#L70) happens right before [`sleep`](https://github.com/logstash-plugins/logstash-codec-multiline/blob/v3.0.10/lib/logstash/codecs/identity_map_codec.rb#L53) on the other thread). 

There's a more technical (isolated) reproducer which served as the inspiration for the spec: https://github.com/logstash-plugins/logstash-codec-multiline/issues/68

There's also a minor refactoring to explicitly declare the concurrent dependency + avoid the legacy `ThreadSafe::Hash` usage in favor of its `Concurrent::Hash` counterpart.

closes https://github.com/logstash-plugins/logstash-codec-multiline/issues/68
