### PR TITLE
Feat: ECS compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 3.0.12
-  - Feat: hook up event_factory support [#69](https://github.com/logstash-plugins/logstash-codec-multiline/pull/69)
+## 3.1.0
+  - Feat: ECS compatibility [#69](https://github.com/logstash-plugins/logstash-codec-multiline/pull/69)
 
 ## 3.0.11
   - Fix: avoid long thread sleeps on codec close [#67](https://github.com/logstash-plugins/logstash-codec-multiline/pull/67)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.12
+  - Feat: hook up event_factory support [#69](https://github.com/logstash-plugins/logstash-codec-multiline/pull/69)
+
 ## 3.0.11
   - Fix: avoid long thread sleeps on codec close [#67](https://github.com/logstash-plugins/logstash-codec-multiline/pull/67)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -102,7 +102,7 @@ following line.
 
 
 [id="plugins-{type}s-{plugin}-options"]
-==== Multiline Codec Configuration Options
+==== Multiline codec configuration options
 
 [cols="<,<,<",options="header",]
 |=======================================================================

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -109,6 +109,7 @@ following line.
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-auto_flush_interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-charset>> |<<string,string>>, one of `["ASCII-8BIT", "UTF-8", "US-ASCII", "Big5", "Big5-HKSCS", "Big5-UAO", "CP949", "Emacs-Mule", "EUC-JP", "EUC-KR", "EUC-TW", "GB2312", "GB18030", "GBK", "ISO-8859-1", "ISO-8859-2", "ISO-8859-3", "ISO-8859-4", "ISO-8859-5", "ISO-8859-6", "ISO-8859-7", "ISO-8859-8", "ISO-8859-9", "ISO-8859-10", "ISO-8859-11", "ISO-8859-13", "ISO-8859-14", "ISO-8859-15", "ISO-8859-16", "KOI8-R", "KOI8-U", "Shift_JIS", "UTF-16BE", "UTF-16LE", "UTF-32BE", "UTF-32LE", "Windows-31J", "Windows-1250", "Windows-1251", "Windows-1252", "IBM437", "IBM737", "IBM775", "CP850", "IBM852", "CP852", "IBM855", "CP855", "IBM857", "IBM860", "IBM861", "IBM862", "IBM863", "IBM864", "IBM865", "IBM866", "IBM869", "Windows-1258", "GB1988", "macCentEuro", "macCroatian", "macCyrillic", "macGreek", "macIceland", "macRoman", "macRomania", "macThai", "macTurkish", "macUkraine", "CP950", "CP951", "IBM037", "stateless-ISO-2022-JP", "eucJP-ms", "CP51932", "EUC-JIS-2004", "GB12345", "ISO-2022-JP", "ISO-2022-JP-2", "CP50220", "CP50221", "Windows-1256", "Windows-1253", "Windows-1255", "Windows-1254", "TIS-620", "Windows-874", "Windows-1257", "MacJapanese", "UTF-7", "UTF8-MAC", "UTF-16", "UTF-32", "UTF8-DoCoMo", "SJIS-DoCoMo", "UTF8-KDDI", "SJIS-KDDI", "ISO-2022-JP-KDDI", "stateless-ISO-2022-JP-KDDI", "UTF8-SoftBank", "SJIS-SoftBank", "BINARY", "CP437", "CP737", "CP775", "IBM850", "CP857", "CP860", "CP861", "CP862", "CP863", "CP864", "CP865", "CP866", "CP869", "CP1258", "Big5-HKSCS:2008", "ebcdic-cp-us", "eucJP", "euc-jp-ms", "EUC-JISX0213", "eucKR", "eucTW", "EUC-CN", "eucCN", "CP936", "ISO2022-JP", "ISO2022-JP2", "ISO8859-1", "ISO8859-2", "ISO8859-3", "ISO8859-4", "ISO8859-5", "ISO8859-6", "CP1256", "ISO8859-7", "CP1253", "ISO8859-8", "CP1255", "ISO8859-9", "CP1254", "ISO8859-10", "ISO8859-11", "CP874", "ISO8859-13", "CP1257", "ISO8859-14", "ISO8859-15", "ISO8859-16", "CP878", "MacJapan", "ASCII", "ANSI_X3.4-1968", "646", "CP65000", "CP65001", "UTF-8-MAC", "UTF-8-HFS", "UCS-2BE", "UCS-4BE", "UCS-4LE", "CP932", "csWindows31J", "SJIS", "PCK", "CP1250", "CP1251", "CP1252", "external", "locale"]`|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-max_bytes>> |<<bytes,bytes>>|No
 | <<plugins-{type}s-{plugin}-max_lines>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-multiline_tag>> |<<string,string>>|No
@@ -143,6 +144,19 @@ This setting is useful if your log files are in `Latin-1` (aka `cp1252`)
 or in another character set other than `UTF-8`.
 
 This only affects "plain" format logs since JSON is `UTF-8` already.
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: plugin only sets the `message` field
+    ** `v1`,`v8`: Elastic Common Schema compliant behavior (`[event][original]` is also added)
+  * Default value depends on which version of Logstash is running:
+    ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+    ** Otherwise, the default value is `disabled`
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
 
 [id="plugins-{type}s-{plugin}-max_bytes"]
 ===== `max_bytes` 

--- a/lib/logstash/codecs/multiline.rb
+++ b/lib/logstash/codecs/multiline.rb
@@ -201,8 +201,8 @@ module LogStash module Codecs class Multiline < LogStash::Codecs::Base
     text = @converter.convert(text)
     text.split("\n").each do |line|
       match = @grok.match(line)
-      @logger.debug("Multiline", :pattern => @pattern, :text => line,
-                    :match => (match != false), :negate => @negate)
+      @logger.debug? && @logger.debug("Multiline", :text => line, :pattern => @pattern,
+                                      :match => (match != false), :negate => @negate)
 
       # Add negate option
       match = (match and !@negate) || (!match and @negate)

--- a/logstash-codec-multiline.gemspec
+++ b/logstash-codec-multiline.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-
+  s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0'
   s.add_runtime_dependency 'logstash-patterns-core'
   s.add_runtime_dependency 'jls-grok', '~> 0.11.1'
   s.add_runtime_dependency 'concurrent-ruby'

--- a/logstash-codec-multiline.gemspec
+++ b/logstash-codec-multiline.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-multiline'
-  s.version         = '3.0.11'
+  s.version         = '3.0.12'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Merges multiline messages into a single event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-codec-multiline.gemspec
+++ b/logstash-codec-multiline.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-multiline'
-  s.version         = '3.0.12'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Merges multiline messages into a single event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.3'
   s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0'
   s.add_runtime_dependency 'logstash-patterns-core'
   s.add_runtime_dependency 'jls-grok', '~> 0.11.1'

--- a/spec/codecs/multiline_spec.rb
+++ b/spec/codecs/multiline_spec.rb
@@ -7,8 +7,9 @@ require_relative "../supports/helpers.rb"
 # above helper also defines a subclass of Multiline
 # called MultilineRspec that exposes the internal buffer
 # and a Logger Mock
+require 'logstash/plugin_mixins/ecs_compatibility_support/spec_helper'
 
-describe LogStash::Codecs::Multiline do
+describe LogStash::Codecs::Multiline, :ecs_compatibility_support do
   context "#decode" do
     let(:config) { {} }
     let(:codec) { LogStash::Codecs::Multiline.new(config).tap {|c| c.register } }
@@ -23,17 +24,35 @@ describe LogStash::Codecs::Multiline do
       end
     end
 
-    it "should be able to handle multiline events with additional lines space-indented" do
-      config.update("pattern" => "^\\s", "what" => "previous")
-      lines = [ "hello world", "   second line", "another first line" ]
-      line_producer.call(lines)
-      codec.flush { |e| events << e }
+    ecs_compatibility_matrix(:disabled, :v1, :v8 => :v1) do |ecs_select|
 
-      expect(events.size).to eq(2)
-      expect(events[0].get("message")).to eq "hello world\n   second line"
-      expect(events[0].get("tags")).to include("multiline")
-      expect(events[1].get("message")).to eq "another first line"
-      expect(events[1].get("tags")).to be_nil
+      before(:each) do
+        allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)
+      end
+
+      let(:config) { super().merge "pattern" => "^\\s", "what" => "previous" }
+      let(:lines) { [ "hello world", "   second line", "another first line" ] }
+
+      let(:expected_first_multiline) { "hello world\n   second line" }
+
+      before do
+        line_producer.call(lines)
+        codec.flush { |e| events << e }
+      end
+
+      it "should be able to handle multiline events with additional lines space-indented" do
+        expect(events.size).to eq(2)
+        expect(events[0].get("message")).to eql expected_first_multiline
+        expect(events[0].get("tags")).to include("multiline")
+        expect(events[1].get("message")).to eql "another first line"
+        expect(events[1].get("tags")).to be_nil
+      end
+
+      it "sets event.original in ECS mode" do
+        expect(events.size).to eq(2)
+        expect(events[0].get("[event][original]")).to eql expected_first_multiline
+      end if ecs_select.active_mode != :disabled
+
     end
 
     it "should allow custom tag added to multiline events" do

--- a/spec/codecs/multiline_spec.rb
+++ b/spec/codecs/multiline_spec.rb
@@ -24,7 +24,7 @@ describe LogStash::Codecs::Multiline, :ecs_compatibility_support do
       end
     end
 
-    ecs_compatibility_matrix(:disabled, :v1, :v8 => :v1) do |ecs_select|
+    ecs_compatibility_matrix(:disabled, :v1, :v8) do |ecs_select|
 
       before(:each) do
         allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)


### PR DESCRIPTION
Added `ecs_compatibility` setting since we still want to set `event.original` in ECS mode.

Also, leveraging LS' `new_event` [factory interface](https://github.com/elastic/logstash/issues/13021).