### PR TITLE
eliminate re-use of codecs across identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.1
+  - Fix: avoid reusing per-identity codec instances for differing identities. Removes a very minor optimization so that stateful codecs like CSV can work reliably. 
+
 ## 3.1.0
   - Feat: ECS compatibility [#69](https://github.com/logstash-plugins/logstash-codec-multiline/pull/69)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.1.1
-  - Fix: avoid reusing per-identity codec instances for differing identities. Removes a very minor optimization so that stateful codecs like CSV can work reliably. 
+  - Fix: avoid reusing per-identity codec instances for differing identities. Removes a very minor optimization so that stateful codecs like CSV can work reliably [#70](https://github.com/logstash-plugins/logstash-codec-multiline/pull/70)
 
 ## 3.1.0
   - Feat: ECS compatibility [#69](https://github.com/logstash-plugins/logstash-codec-multiline/pull/69)

--- a/lib/logstash/codecs/identity_map_codec.rb
+++ b/lib/logstash/codecs/identity_map_codec.rb
@@ -290,6 +290,7 @@ module LogStash module Codecs class IdentityMapCodec
   end
 
   def codec_without_usage_update(identity)
+    return base_codec if identity.nil? # mirror optimization in `stream_codec`
     find_codec_value(identity).codec
   end
 
@@ -336,7 +337,7 @@ module LogStash module Codecs class IdentityMapCodec
   end
 
   def codec_builder(hash, k)
-    codec = hash.empty? ? @base_codec : @base_codec.clone
+    codec = @base_codec.clone
     codec.use_mapper_auto_flush if using_mapped_auto_flush?
     compo = CodecValue.new(codec).tap do |o|
       now = Time.now

--- a/logstash-codec-multiline.gemspec
+++ b/logstash-codec-multiline.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-multiline'
-  s.version         = '3.1.0'
+  s.version         = '3.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Merges multiline messages into a single event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Some Logstash codecs (like CSV) are stateful and cannot be reused across
multiple input streams. This change removes a minor optimization, in which
the base codec is repeatedly reused for the first concurrent accessor, despite
the identities for the identity map not matching previous usages. Instead, when
an identity is provided, we ensure that a _clone_ of the base codec is provided
for each distinct identity up and until eviction, and that the clone is not
reused after its eviction flush.