### PR TITLE
Fix non stop periodic runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.2
+  - Fix: periodic runner fails to stop and prevent pipeline shutdown [#72](https://github.com/logstash-plugins/logstash-codec-multiline/pull/72)
+
 ## 3.1.1
   - Fix: avoid reusing per-identity codec instances for differing identities. Removes a very minor optimization so that stateful codecs like CSV can work reliably [#70](https://github.com/logstash-plugins/logstash-codec-multiline/pull/70)
 

--- a/lib/logstash/codecs/identity_map_codec.rb
+++ b/lib/logstash/codecs/identity_map_codec.rb
@@ -320,7 +320,7 @@ module LogStash module Codecs class IdentityMapCodec
   def record_codec_usage(identity)
     check_map_limits
     # only start the cleaner if streams are in use
-    # continuous calls to start are OK if this codec instance is accessed by a single thread
+    # continuous calls to start are OK if this codec method is accessed by a single thread
     cleaner.start
     auto_flusher.start
     compo = find_codec_value(identity)

--- a/logstash-codec-multiline.gemspec
+++ b/logstash-codec-multiline.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-multiline'
-  s.version         = '3.1.1'
+  s.version         = '3.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Merges multiline messages into a single event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixes: https://github.com/logstash-plugins/logstash-input-file/issues/325

Periodic runner blocks the pipeline to shut down due to multiple threads access and set `running`.
This commit prevents multiple threads from interfering and allows the cleaner to finish properly.

IdentityMapCodec is used in file-input and [lumberjack-input](https://github.com/logstash-plugins/logstash-input-lumberjack/blob/main/lib/logstash/inputs/lumberjack.rb#L70)
