### PR TITLE
Fix concurrency issue with multiline codec and other grok-based plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.1.3
-  - Fix: concurrency issue with multiline codec and other grok-based plugins [#TBD](https://github.com/logstash-plugins/logstash-codec-multiline/pull/TBD)
+  - Fix: concurrency issue with multiline codec and other grok-based plugins [#75](https://github.com/logstash-plugins/logstash-codec-multiline/pull/75)
 
 ## 3.1.2
   - Fix: periodic runner fails to stop and prevent pipeline shutdown [#72](https://github.com/logstash-plugins/logstash-codec-multiline/pull/72)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.3
+  - Fix: concurrency issue with multiline codec and other grok-based plugins [#TBD](https://github.com/logstash-plugins/logstash-codec-multiline/pull/TBD)
+
 ## 3.1.2
   - Fix: periodic runner fails to stop and prevent pipeline shutdown [#72](https://github.com/logstash-plugins/logstash-codec-multiline/pull/72)
 

--- a/lib/logstash/codecs/multiline.rb
+++ b/lib/logstash/codecs/multiline.rb
@@ -5,6 +5,7 @@ require "logstash/timestamp"
 require "logstash/codecs/auto_flush"
 require 'logstash/plugin_mixins/ecs_compatibility_support'
 require 'logstash/plugin_mixins/event_support/event_factory_adapter'
+require "grok-pure" # rubygem 'jls-grok'
 
 # The multiline codec will collapse multiline messages and merge them into a
 # single event.
@@ -155,7 +156,6 @@ module LogStash module Codecs class Multiline < LogStash::Codecs::Base
   end
 
   def register
-    require "grok-pure" # rubygem 'jls-grok'
     require 'logstash/patterns/core'
 
     # Detect if we are running from a jarfile, pick the right path.

--- a/logstash-codec-multiline.gemspec
+++ b/logstash-codec-multiline.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-multiline'
-  s.version         = '3.1.2'
+  s.version         = '3.1.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Merges multiline messages into a single event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixed a concurrency issue with multiline codec and other grok-based plugins, that when combined, was generating the following error:

```
{:action=>LogStash::PipelineAction::Create/pipeline_id:pipeline2, :exception=>"Java::JavaLang::IllegalStateException", :message=>"Unable to configure plugins: (LoadError) load error: cabin/mixins/logger -- java.lang.StringIndexOutOfBoundsException: Index -1 out of bounds for length 16"}
```
