### PR TITLE
CI-Fix:Add exponential backoff retries to ensure auto-flush mechanism runs before assertion

### DIFF
--- a/spec/codecs/identity_map_codec_spec.rb
+++ b/spec/codecs/identity_map_codec_spec.rb
@@ -271,8 +271,9 @@ describe LogStash::Codecs::IdentityMapCodec do
           l_2 = Mlc::LineListener.new(queue, imc, "stream3").tap {|o| o.accept("baz")}
         end
         it "three events are auto flushed from three different identities/codecs" do
-          sleep 1 # wait for auto_flush 2 PeriodicRunner cycles to ensure it is executed before assertion.
-          expect(queue.size).to eq(3)
+          sleep 0.6 # wait for auto_flush 1 PeriodicRunner cycle before assertion.
+          # try a few times with exponential backoff as timing is not 100% guaranteed
+          try(10) { expect(queue.size).to eq(3) }
           e1, e2, e3 = queue
           expect(e1.get("path")).to eq("stream1")
           expect(e1.get("message")).to eq("foo")

--- a/spec/codecs/identity_map_codec_spec.rb
+++ b/spec/codecs/identity_map_codec_spec.rb
@@ -271,7 +271,7 @@ describe LogStash::Codecs::IdentityMapCodec do
           l_2 = Mlc::LineListener.new(queue, imc, "stream3").tap {|o| o.accept("baz")}
         end
         it "three events are auto flushed from three different identities/codecs" do
-          sleep 0.6 # wait for auto_flush - in multiples of 0.5 plus 0.1
+          sleep 1 # wait for auto_flush 2 PeriodicRunner cycles to ensure it is executed before assertion.
           expect(queue.size).to eq(3)
           e1, e2, e3 = queue
           expect(e1.get("path")).to eq("stream1")


### PR DESCRIPTION
The [test](https://github.com/logstash-plugins/logstash-codec-multiline/blob/main/spec/codecs/identity_map_codec_spec.rb#L267)  was waiting for `auto-flusher` to be executed and flushed after 0.6s (0.5s of [auto-flusher cycle](https://github.com/logstash-plugins/logstash-codec-multiline/blob/main/lib/logstash/codecs/identity_map_codec.rb#L133) + 0.1s of grace period. Depending on thread scheduling, this 0.6s wait was not always sufficient for the flush to complete before assertions were checked, causing the test to fail.

The sleep duration has been increased to ensure the auto-flush mechanism is executed at least once.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
